### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,19 +3,19 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.4.2",
+      "version": "7.4.5",
       "commands": [
         "pwsh"
       ]
     },
     "dotnet-coverage": {
-      "version": "17.11.3",
+      "version": "17.12.5",
       "commands": [
         "dotnet-coverage"
       ]
     },
     "nbgv": {
-      "version": "3.6.139",
+      "version": "3.6.143",
       "commands": [
         "nbgv"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:8.0.300-jammy
+FROM mcr.microsoft.com/dotnet/sdk:8.0.402-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.editorconfig
+++ b/.editorconfig
@@ -185,5 +185,8 @@ dotnet_diagnostic.DOC202.severity = warning
 # CA1062: Validate arguments of public methods
 dotnet_diagnostic.CA1062.severity = warning
 
+# CA2016: Forward the CancellationToken parameter
+dotnet_diagnostic.CA2016.severity = warning
+
 [*.sln]
 indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,6 @@ MigrationBackup/
 
 # mac-created file to track user view preferences for a directory
 .DS_Store
+
+# Analysis results
+*.sarif

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,6 @@
     <BaseIntermediateOutputPath>$(RepoRootPath)obj\$([MSBuild]::MakeRelative($(RepoRootPath), $(MSBuildProjectDirectory)))\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\</PackageOutputPath>
-    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AnalysisLevel>latest</AnalysisLevel>
@@ -55,23 +54,4 @@
       <PackageReleaseNotes Condition="'$(PackageProjectUrl)'!=''">$(PackageProjectUrl)/releases/tag/v$(Version)</PackageReleaseNotes>
     </PropertyGroup>
   </Target>
-
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == ''">
-    <IsWpfTempProject>false</IsWpfTempProject>
-    <IsWpfTempProject Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
-  </PropertyGroup>
-
-  <!--
-    Inspired by https://github.com/dotnet/arcade/blob/cbfa29d4e859622ada3d226f90f103f659665d31/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props#L14-L31
-
-    Disable Source Link and Xliff in WPF temp projects to avoid generating non-deterministic file names to obj dir.
-    The project name is non-deterministic and is included in the Source Link json file name and xlf directory names.
-    It's also not necessary to generate these assets.
-  -->
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == 'true'">
-    <EnableSourceLink>false</EnableSourceLink>
-    <EmbedUntrackedSources>false</EmbedUntrackedSources>
-    <DeterministicSourcePaths>false</DeterministicSourcePaths>
-    <EnableXlfLocalization>false</EnableXlfLocalization>
-  </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <!-- Workaround https://github.com/dotnet/wpf/issues/1718 -->
-    <EmbedUntrackedSources Condition=" '$(UseWPF)' == 'true' ">false</EmbedUntrackedSources>
+    <LangVersion Condition="'$(Language)'=='C#'">12</LangVersion>
+    <LangVersion Condition="'$(Language)'=='VB'">16.9</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Avoid compile error about missing namespace when combining ImplicitUsings with .NET Framework target frameworks. -->
     <Using Remove="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,21 +6,18 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />
     <PackageVersion Include="Nerdbank.NetStandardBridge" Version="1.1.32-alpha" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
-    <PackageVersion Include="xunit" Version="2.8.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />
+    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.139" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.143" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
-  </ItemGroup>
-  <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines/Get-LibTemplateBasis.ps1
+++ b/azure-pipelines/Get-LibTemplateBasis.ps1
@@ -1,0 +1,25 @@
+<#
+.SYNOPSIS
+    Returns the name of the well-known branch in the Library.Template repository upon which HEAD is based.
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+Param(
+    [switch]$ErrorIfNotRelated
+)
+
+# This list should be sorted in order of decreasing specificity.
+$branchMarkers = @(
+    @{ commit = 'fd0a7b25ccf030bbd16880cca6efe009d5b1fffc'; branch = 'microbuild' };
+    @{ commit = '05f49ce799c1f9cc696d53eea89699d80f59f833'; branch = 'main' };
+)
+
+foreach ($entry in $branchMarkers) {
+    if (git rev-list HEAD | Select-String -Pattern $entry.commit) {
+        return $entry.branch
+    }
+}
+
+if ($ErrorIfNotRelated) {
+    Write-Error "Library.Template has not been previously merged with this repo. Please review https://github.com/AArnott/Library.Template/tree/main?tab=readme-ov-file#readme for instructions."
+    exit 1
+}

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -23,3 +23,4 @@ jobs:
     displayName: 💅 Verify formatted code
 
   - template: publish-deployables.yml
+  - template: publish-codecoverage.yml

--- a/azure-pipelines/libtemplate-update.yml
+++ b/azure-pipelines/libtemplate-update.yml
@@ -1,0 +1,146 @@
+# This pipeline schedules regular merges of Library.Template into a repo that is based on it.
+# Only Azure Repos are supported. GitHub support comes via a GitHub Actions workflow.
+
+trigger: none
+pr: none
+schedules:
+- cron: "0 3 * * Mon" # Sun @ 8 or 9 PM Mountain Time (depending on DST)
+  displayName: Weekly trigger
+  branches:
+    include:
+    - main
+  always: true
+
+parameters:
+- name: AutoComplete
+  displayName: Auto-complete pull request
+  type: boolean
+  default: false
+
+stages:
+- stage: Merge
+  jobs:
+  - job: merge
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+    - checkout: self
+      fetchDepth: 0
+      clean: true
+    - pwsh: |
+        $LibTemplateBranch = & ./azure-pipelines/Get-LibTemplateBasis.ps1 -ErrorIfNotRelated
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+
+        git fetch https://github.com/aarnott/Library.Template $LibTemplateBranch
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+        $LibTemplateCommit = git rev-parse FETCH_HEAD
+
+        if ((git rev-list FETCH_HEAD ^HEAD --count) -eq 0) {
+          Write-Host "There are no Library.Template updates to merge."
+          exit 0
+        }
+
+        $UpdateBranchName = 'auto/libtemplateUpdate'
+        git -c http.extraheader="AUTHORIZATION: bearer $(System.AccessToken)" push origin -f FETCH_HEAD:refs/heads/$UpdateBranchName
+
+        Write-Host "Creating pull request"
+        $contentType = 'application/json';
+        $headers = @{ Authorization = 'Bearer $(System.AccessToken)' };
+        $rawRequest = @{
+          sourceRefName = "refs/heads/$UpdateBranchName";
+          targetRefName = "refs/heads/main";
+          title = 'Merge latest Library.Template';
+          description = "This merges the latest features and fixes from [Library.Template's $LibTemplateBranch branch](https://github.com/AArnott/Library.Template/tree/$LibTemplateBranch).";
+        }
+        $request = ConvertTo-Json $rawRequest
+
+        $prApiBaseUri = '$(System.TeamFoundationCollectionUri)/$(System.TeamProject)/_apis/git/repositories/$(Build.Repository.ID)/pullrequests'
+        $prCreationUri = $prApiBaseUri + "?api-version=6.0"
+        Write-Host "POST $prCreationUri"
+        Write-Host $request
+
+        $prCreationResult = Invoke-RestMethod -uri $prCreationUri -method POST -Headers $headers -ContentType $contentType -Body $request
+        $prUrl = "$($prCreationResult.repository.webUrl)/pullrequest/$($prCreationResult.pullRequestId)"
+        Write-Host "Pull request: $prUrl"
+        $prApiBaseUri += "/$($prCreationResult.pullRequestId)"
+
+        $SummaryPath = Join-Path '$(Agent.TempDirectory)' 'summary.md'
+        Set-Content -Path $SummaryPath -Value "[Insertion pull request]($prUrl)"
+        Write-Host "##vso[task.uploadsummary]$SummaryPath"
+
+        # Tag the PR
+        $tagUri = "$prApiBaseUri/labels?api-version=7.0"
+        $rawRequest = @{
+          name = 'auto-template-merge';
+        }
+        $request = ConvertTo-Json $rawRequest
+        Invoke-RestMethod -uri $tagUri -method POST -Headers $headers -ContentType $contentType -Body $request | Out-Null
+
+        # Add properties to the PR that we can programatically parse later.
+        Function Set-PRProperties($properties) {
+          $rawRequest = $properties.GetEnumerator() |% {
+            @{
+              op = 'add'
+              path = "/$($_.key)"
+              from = $null
+              value = $_.value
+            }
+          }
+          $request = ConvertTo-Json $rawRequest
+          $setPrPropertyUri = "$prApiBaseUri/properties?api-version=7.0"
+          Write-Debug "$request"
+          $setPrPropertyResult = Invoke-RestMethod -uri $setPrPropertyUri -method PATCH -Headers $headers -ContentType 'application/json-patch+json' -Body $request -StatusCodeVariable setPrPropertyStatus -SkipHttpErrorCheck
+          if ($setPrPropertyStatus -ne 200) {
+            Write-Host "##vso[task.logissue type=warning]Failed to set pull request properties. Result: $setPrPropertyStatus. $($setPrPropertyResult.message)"
+          }
+        }
+        Write-Host "Setting pull request properties"
+        Set-PRProperties @{
+          'AutomatedMerge.SourceBranch' = $LibTemplateBranch
+          'AutomatedMerge.SourceCommit' = $LibTemplateCommit
+        }
+
+        # Add an *active* PR comment to warn users to *merge* the pull request instead of squash it.
+        $request = ConvertTo-Json @{
+          comments = @(
+            @{
+              parentCommentId = 0
+              content = "Do **not** squash this pull request when completing it. You must *merge* it."
+              commentType = 'system'
+            }
+          )
+          status = 'active'
+        }
+        $result = Invoke-RestMethod -uri "$prApiBaseUri/threads?api-version=7.1" -method POST -Headers $headers -ContentType $contentType -Body $request -StatusCodeVariable addCommentStatus -SkipHttpErrorCheck
+        if ($addCommentStatus -ne 200) {
+          Write-Host "##vso[task.logissue type=warning]Failed to post comment on pull request. Result: $addCommentStatus. $($result.message)"
+        }
+
+        # Set auto-complete on the PR
+        if ('${{ parameters.AutoComplete }}' -eq 'True') {
+          Write-Host "Setting auto-complete"
+          $mergeMessage = "Merged PR $($prCreationResult.pullRequestId): " + $commitMessage
+          $rawRequest = @{
+            autoCompleteSetBy = @{
+              id = $prCreationResult.createdBy.id
+            };
+            completionOptions = @{
+              deleteSourceBranch = $true;
+              mergeCommitMessage = $mergeMessage;
+              mergeStrategy = 'noFastForward';
+            };
+          }
+          $request = ConvertTo-Json $rawRequest
+          Write-Host $request
+          $uri = "$($prApiBaseUri)?api-version=6.0"
+          $result = Invoke-RestMethod -uri $uri -method PATCH -Headers $headers -ContentType $contentType -Body $request -StatusCodeVariable autoCompleteStatus -SkipHttpErrorCheck
+          if ($autoCompleteStatus -ne 200) {
+            Write-Host "##vso[task.logissue type=warning]Failed to set auto-complete on pull request. Result: $autoCompleteStatus. $($result.message)"
+          }
+        }
+
+      displayName: Create pull request

--- a/azure-pipelines/publish-codecoverage.yml
+++ b/azure-pipelines/publish-codecoverage.yml
@@ -1,0 +1,11 @@
+parameters:
+  includeMacOS:
+
+steps:
+- powershell: azure-pipelines/Merge-CodeCoverage.ps1 -Path '$(Pipeline.Workspace)' -OutputFile coveragereport/merged.cobertura.xml -Format Cobertura -Verbose
+  displayName: ⚙ Merge coverage
+- task: PublishCodeCoverageResults@2
+  displayName: 📢 Publish code coverage results to Azure DevOps
+  inputs:
+    summaryFileLocation: coveragereport/merged.cobertura.xml
+    failIfCoverageEmpty: true

--- a/azurepipelines-coverage.yml
+++ b/azurepipelines-coverage.yml
@@ -1,0 +1,6 @@
+# https://learn.microsoft.com/azure/devops/pipelines/test/codecoverage-for-pullrequests?view=azure-devops
+coverage:
+  status:
+    comments: on    # add comment to PRs reporting diff in coverage of modified files
+    diff:           # diff coverage is code coverage only for the lines changed in a pull request.
+      target: 70%   # set this to a desired %. Default is 70%

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.300",
+    "version": "8.0.402",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/src/AssemblyInfo.vb
+++ b/src/AssemblyInfo.vb
@@ -1,0 +1,6 @@
+' Copyright (c) COMPANY-PLACEHOLDER. All rights reserved.
+' Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+Imports System.Runtime.InteropServices
+
+<Assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" Condition=" '$(Language)'=='C#' " />
+    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.vb" Condition=" '$(Language)'=='VB' " />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />

--- a/tools/MergeFrom-Template.ps1
+++ b/tools/MergeFrom-Template.ps1
@@ -1,0 +1,79 @@
+
+<#
+.SYNOPSIS
+    Merges the latest changes from Library.Template into HEAD of this repo.
+.PARAMETER LocalBranch
+    The name of the local branch to create at HEAD and use to merge into from Library.Template.
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+Param(
+    [string]$LocalBranch = "dev/$($env:USERNAME)/libtemplateUpdate"
+)
+
+Function Spawn-Tool($command, $commandArgs, $workingDirectory, $allowFailures) {
+    if ($workingDirectory) {
+        Push-Location $workingDirectory
+    }
+    try {
+        if ($env:TF_BUILD) {
+            Write-Host "$pwd >"
+            Write-Host "##[command]$command $commandArgs"
+        }
+        else {
+            Write-Host "$command $commandArgs" -ForegroundColor Yellow
+        }
+        if ($commandArgs) {
+            & $command @commandArgs
+        } else {
+            Invoke-Expression $command
+        }
+        if ((!$allowFailures) -and ($LASTEXITCODE -ne 0)) { exit $LASTEXITCODE }
+    }
+    finally {
+        if ($workingDirectory) {
+            Pop-Location
+        }
+    }
+}
+
+$remoteBranch = & $PSScriptRoot\..\azure-pipelines\Get-LibTemplateBasis.ps1 -ErrorIfNotRelated
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+$LibTemplateUrl = 'https://github.com/aarnott/Library.Template'
+Spawn-Tool 'git' ('fetch', $LibTemplateUrl, $remoteBranch)
+$SourceCommit = git rev-parse FETCH_HEAD
+$BaseBranch = Spawn-Tool 'git' ('branch', '--show-current')
+$SourceCommitUrl = "$LibTemplateUrl/commit/$SourceCommit"
+
+# To reduce the odds of merge conflicts at this stage, we always move HEAD to the last successful merge.
+$basis = Spawn-Tool 'git' ('rev-parse', 'HEAD') # TODO: consider improving this later
+
+Write-Host "Merging the $remoteBranch branch of Library.Template ($SourceCommit) into local repo $basis" -ForegroundColor Green
+
+Spawn-Tool 'git' ('checkout', '-b', $LocalBranch, $basis) $null $true
+if ($LASTEXITCODE -eq 128) {
+    Spawn-Tool 'git' ('checkout', $LocalBranch)
+    Spawn-Tool 'git' ('merge', $basis)
+}
+
+Spawn-Tool 'git' ('merge', 'FETCH_HEAD', '--no-ff', '-m', "Merge the $remoteBranch branch from $LibTemplateUrl`n`nSpecifically, this merges [$SourceCommit from that repo]($SourceCommitUrl).")
+if ($LASTEXITCODE -eq 1) {
+    Write-Error "Merge conflict detected. Manual resolution required."
+    exit 1
+}
+elseif ($LASTEXITCODE -ne 0) {
+    Write-Error "Merge failed with exit code $LASTEXITCODE."
+    exit $LASTEXITCODE
+}
+
+$result = New-Object PSObject -Property @{
+    BaseBranch   = $BaseBranch   # The original branch that was checked out when the script ran.
+    LocalBranch  = $LocalBranch  # The name of the local branch that was created before the merge.
+    SourceCommit = $SourceCommit # The commit from Library.Template that was merged in.
+    SourceBranch = $remoteBranch # The branch from Library.Template that was merged in.
+}
+
+Write-Host $result
+Write-Output $result


### PR DESCRIPTION
- **Update PublishCodeCoverageResults task to v2**
- **Drop SourceLink package reference**
- **Remove WPF workarounds for bugs fixed years ago**
- **Bump powershell from 7.4.2 to 7.4.3 (#275)**
- **Ignore .sarif files**
- **Add support for VB.NET projects**
- **Fix template expansion**
- **Bump several dependencies**
- **Fix github actions warnings**
- **Skip codecov publishing without token**
- **Enable CA2016: forward the CancellationToken**
- **Bump powershell from 7.4.3 to 7.4.4 (#277)**
- **Bump Nerdbank.GitVersioning from 3.6.139 to 3.6.141 (#280)**
- **Bump nbgv from 3.6.139 to 3.6.141 (#279)**
- **Bump dotnet-coverage from 17.11.3 to 17.11.5 (#278)**
- **Bump .NET SDK to 8.0.400**
- **Post code coverage diff comments for AzDO PRs**
- **Bump Microsoft.NET.Test.Sdk to 17.11**
- **Bump powershell from 7.4.4 to 7.4.5 (#282)**
- **Bump Nerdbank.GitVersioning from 3.6.141 to 3.6.143 (#283)**
- **Bump nbgv from 3.6.141 to 3.6.143 (#284)**
- **Bump dotnet-coverage from 17.11.5 to 17.12.2 (#285)**
- **Bump dotnet-coverage from 17.12.2 to 17.12.3 (#288)**
- **Bump Microsoft.NET.Test.Sdk from 17.11.0 to 17.11.1 (#287)**
- **Bump dotnet-coverage from 17.12.3 to 17.12.4 (#289)**
- **Bump xunit from 2.9.0 to 2.9.1 (#290)**
- **Bump dotnet-coverage from 17.12.4 to 17.12.5 (#292)**
- **Bump xunit from 2.9.1 to 2.9.2 (#291)**
- **Build on ubuntu 22 in cloud builds**
- **Add AzDO pipeline to help keep repos up-to-date**
- **Bump .NET SDK to 8.0.402**
- **Fix linux agent on AzDO**
- **Update build agent to macos-14**
